### PR TITLE
Remove hizashi-utils.

### DIFF
--- a/deployment/docker-dev/REQUIREMENTS-dev.txt
+++ b/deployment/docker-dev/REQUIREMENTS-dev.txt
@@ -11,8 +11,3 @@ Sphinx
 
 # pdb plus plus
 pdbpp
-
-# hizashi-utils
-hizashi-utils==0.4.1
-
-


### PR DESCRIPTION
This package still needs Django<1.8, meanwhile we need Celery 4.1 that needs Django==1.8.