### PR TITLE
Unittests improvement and celery callback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -111,6 +111,7 @@ django_project/celerybeat.pid
 django_project/celerybeat-schedule
 django_project/temp
 deployment/realtime-hazard
+!deployment/realtime-hazard/shakemaps/.gitkeep
 
 sftp_media_credential.env
 sftp_pg_credential.env
@@ -139,4 +140,3 @@ deployment/headless-data/outputs/
 deployment/headless-data/qgis-templates/
 deployment/headless-data/test-hazards/
 deployment/reports/
-

--- a/deployment/ansible/development/roles/pycharm/templates/workspace-configuration.xml.j2
+++ b/deployment/ansible/development/roles/pycharm/templates/workspace-configuration.xml.j2
@@ -22,8 +22,6 @@
       <option name="PARENT_ENVS" value="true" />
       <envs>
         {% include 'run-manager-environment.xml.j2' %}
-
-        <env name="TASK_ALWAYS_EAGER" value="True" />
       </envs>
       <option name="SDK_HOME" value="ssh://root@{{ interpreters.inasafe_django.domain_alias }}:{{ interpreters.inasafe_django.ssh_port }}/usr/local/bin/python" />
       <option name="WORKING_DIRECTORY" value="" />
@@ -386,6 +384,27 @@
       <option name="PARAMETERS" value="-A core.celery_app worker --loglevel=info -Q inasafe-django-indicator -B -n indicator.%h" />
       <option name="SHOW_COMMAND_LINE" value="false" />
       <method />
+    </configuration>
+    <configuration name="Run Realtime Tests" type="PythonConfigurationType" factoryName="Python">
+      <option name="INTERPRETER_OPTIONS" value="" />
+      <option name="PARENT_ENVS" value="true" />
+      <envs>
+        {% include 'run-manager-environment.xml.j2' %}
+
+        <env name="TASK_ALWAYS_EAGER" value="True" />
+      </envs>
+      <option name="SDK_HOME" value="ssh://root@{{ interpreters.inasafe_django.domain_alias }}:{{ interpreters.inasafe_django.ssh_port }}/usr/local/bin/python" />
+      <option name="WORKING_DIRECTORY" value="" />
+      <option name="IS_MODULE_SDK" value="false" />
+      <option name="ADD_CONTENT_ROOTS" value="true" />
+      <option name="ADD_SOURCE_ROOTS" value="true" />
+      <module name="inasafe-django" />
+      <EXTENSION ID="PythonCoverageRunConfigurationExtension" enabled="false" sample_coverage="true" runner="coverage.py" />
+      <option name="SCRIPT_NAME" value="./manage.py" />
+      <option name="PARAMETERS" value="test --liveserver=0.0.0.0:8080 --noinput realtime.tasks.realtime.test.test_realtime_tasks" />
+      <option name="SHOW_COMMAND_LINE" value="false" />
+      <option name="EMULATE_TERMINAL" value="false" />
+      <option name="MODULE_MODE" value="false" />
     </configuration>
     <configuration default="false" name="Import Boundary (Kelurahan)" type="PythonConfigurationType" factoryName="Python">
       <option name="INTERPRETER_OPTIONS" value="" />

--- a/deployment/docker-dev/REQUIREMENTS.txt
+++ b/deployment/docker-dev/REQUIREMENTS.txt
@@ -25,3 +25,5 @@ beautifulsoup4==4.5.1
 django-tinymce==2.6
 django-filebrowser==3.7.2
 django-tinymce-filebrowser==0.2.1
+urllib3==1.22
+pyyaml==3.12

--- a/deployment/production/docker/uwsgi/REQUIREMENTS.txt
+++ b/deployment/production/docker/uwsgi/REQUIREMENTS.txt
@@ -25,3 +25,5 @@ beautifulsoup4==4.5.1
 django-tinymce==2.6
 django-filebrowser==3.7.2
 django-tinymce-filebrowser==0.2.1
+urllib3==1.22
+pyyaml==3.12

--- a/deployment/realtime-hazard/shakemaps/.gitkeep
+++ b/deployment/realtime-hazard/shakemaps/.gitkeep
@@ -1,0 +1,1 @@
+This folder need to exists for shakemaps drop watchers unittests

--- a/django_project/core/settings/celery_config.py
+++ b/django_project/core/settings/celery_config.py
@@ -79,14 +79,6 @@ beat_schedule = {
         }
     },
     # executes every minute
-    'check-realtime-earthquake-processing': {
-        'task': 'realtime.tasks.earthquake.check_processing_task',
-        'schedule': crontab(minute='*'),
-        'options': {
-            'queue': 'inasafe-django'
-        }
-    },
-    # executes every minute
     'check-realtime-flood-processing': {
         'task': 'realtime.tasks.flood.check_processing_task',
         'schedule': crontab(minute='*'),

--- a/django_project/realtime/app_settings.py
+++ b/django_project/realtime/app_settings.py
@@ -195,12 +195,12 @@ EARTHQUAKE_EXPOSURES = [
 ]
 EARTHQUAKE_AGGREGATION = ''
 EARTHQUAKE_REPORT_TEMPLATE = '/home/headless/qgis-templates/' \
-                             'realtime-earthquake-en.qpt'
+                             'earthquake/realtime-earthquake-en.qpt'
 EARTHQUAKE_LAYER_ORDER = [
-    '/home/headless/contexts/common/exposure/WorldPop_200m.tif',
-    '@population.earthquake_contour',
     '/home/headless/contexts/common/exposure/'
     'IDN_Capital_Population_Point_WGS84.shp',
+    '@population.earthquake_contour',
+    '/home/headless/contexts/common/exposure/WorldPop_200m.tif',
 ]
 
 EARTHQUAKE_EVENT_REPORT_FORMAT = getattr(

--- a/django_project/realtime/migrations/0040_auto_20180222_1053.py
+++ b/django_project/realtime/migrations/0040_auto_20180222_1053.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('realtime', '0039_auto_20180220_1713'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='earthquake',
+            name='analysis_task_result',
+            field=models.TextField(default=b'', help_text='Task result of analysis run', null=True, verbose_name='Analysis celery task result', blank=True),
+        ),
+        migrations.AddField(
+            model_name='earthquake',
+            name='mmi_output_path',
+            field=models.CharField(default=None, max_length=255, blank=True, help_text='MMI related file path location', null=True, verbose_name='MMI related file path'),
+        ),
+        migrations.AddField(
+            model_name='earthquake',
+            name='report_task_result',
+            field=models.TextField(default=b'', help_text='Task result of report generation', null=True, verbose_name='Report celery task result', blank=True),
+        ),
+    ]

--- a/django_project/realtime/migrations/0041_merge.py
+++ b/django_project/realtime/migrations/0041_merge.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('realtime', '0040_auto_20180222_1053'),
+        ('realtime', '0040_auto_20180223_0326'),
+    ]
+
+    operations = [
+    ]

--- a/django_project/realtime/models/earthquake.py
+++ b/django_project/realtime/models/earthquake.py
@@ -292,6 +292,14 @@ class EarthquakeReport(models.Model):
         super(EarthquakeReport, self).delete(using=using)
 
     @property
+    def shake_id(self):
+        return self.earthquake.shake_id
+
+    @property
+    def source_type(self):
+        return self.earthquake.source_type
+
+    @property
     def report_map_filename(self):
         """Return standardized filename for report map."""
         return EARTHQUAKE_EVENT_REPORT_FORMAT.format(

--- a/django_project/realtime/models/volcano.py
+++ b/django_project/realtime/models/volcano.py
@@ -1,4 +1,5 @@
 # coding=utf-8
+import logging
 
 from django.contrib.gis.db import models
 from django.contrib.gis.gdal.datasource import DataSource
@@ -6,8 +7,13 @@ from django.contrib.gis.geos.geometry import GEOSGeometry
 from django.contrib.gis.geos.point import Point
 from django.utils.translation import ugettext_lazy as _
 
+from realtime.app_settings import LOGGER_NAME
+
 __author__ = 'Rizky Maulana Nugraha <lana.pcfre@gmail.com>'
 __date__ = '7/18/16'
+
+
+LOGGER = logging.getLogger(LOGGER_NAME)
 
 
 class Volcano(models.Model):
@@ -105,7 +111,8 @@ def load_volcano_data(Volcano, volcano_shapefile):
                 province__iexact=province,
                 district__iexact=district,
                 morphology__iexact=morphology,)
-            print 'Volcano %s already exists' % volcano.volcano_name
+            LOGGER.info(
+                'Volcano {0} already exists'.format(volcano.volcano_name))
         except Volcano.DoesNotExist:
             volcano = Volcano.objects.create(
                 volcano_name=volcano_name,
@@ -116,4 +123,5 @@ def load_volcano_data(Volcano, volcano_shapefile):
                 morphology=morphology,
                 province=province,
                 district=district)
-            print 'Volcano %s created' % volcano.volcano_name
+            LOGGER.debug(
+                'Volcano {0} created'.format(volcano.volcano_name))

--- a/django_project/realtime/serializers/earthquake_serializer.py
+++ b/django_project/realtime/serializers/earthquake_serializer.py
@@ -15,18 +15,25 @@ __date__ = '19/06/15'
 
 class EarthquakeReportSerializer(serializers.ModelSerializer):
 
-    shake_id = serializers.SlugRelatedField(
-        queryset=Earthquake.objects.all(),
-        read_only=False,
-        slug_field='shake_id',
-        source='earthquake'
-    )
-    source_type = serializers.SlugRelatedField(
-        queryset=Earthquake.objects.all(),
-        read_only=False,
-        slug_field='source_type',
-        source='earthquake'
-    )
+    # def get_shake_id(self, serializer_field, obj):
+    #     """
+    #     :param serializer_field:
+    #     :type serializer_field: CustomSerializerMethodField
+    #     :param obj:
+    #     :type obj: EarthquakeReport
+    #     :return:
+    #     """
+    #     return obj.earthquake.shake_id
+    #
+    # def get_source_type(self, serializer_field, obj):
+    #     """
+    #     :param serializer_field:
+    #     :type serializer_field: CustomSerializerMethodField
+    #     :param obj:
+    #     :type obj: EarthquakeReport
+    #     :return:
+    #     """
+    #     return obj.earthquake.source_type
 
     def get_url(self, serializer_field, obj):
         """

--- a/django_project/realtime/serializers/earthquake_serializer.py
+++ b/django_project/realtime/serializers/earthquake_serializer.py
@@ -140,12 +140,13 @@ class EarthquakeGeoJsonSerializer(GeoFeatureModelSerializer):
         fields = (
             'shake_id',
             'shake_grid',
+            'shake_grid_download_url',
             'mmi_output',
+            'analysis_zip_download_url',
             'magnitude',
             'time',
             'depth',
             'location',
             'location_description',
             'felt',
-            'source_type'
-        )
+            'source_type')

--- a/django_project/realtime/static/realtime/js/earthquake/shake.js
+++ b/django_project/realtime/static/realtime/js/earthquake/shake.js
@@ -176,14 +176,14 @@ function createDownloadGridHandler(grid_url) {
         // replace magic number 000 with shake_id
         url = url.replace('000', shake_id);
         var shake_list = dynaTable.settings.dataset.originalRecords;
-        var shake_grid;
+        var shake_grid_exists;
         for(var i=0;i < shake_list.length;i++){
             if(shake_id == shake_list[i].shake_id){
-                shake_grid = shake_list[i].shake_grid;
+                shake_grid_exists = shake_list[i].shake_grid_exists;
                 break;
             }
         }
-        if(shake_grid){
+        if(shake_grid_exists){
             SaveToDisk(url, shake_id + '-grid.xml');
         }
         else{

--- a/django_project/realtime/tasks/earthquake.py
+++ b/django_project/realtime/tasks/earthquake.py
@@ -32,7 +32,7 @@ LOGGER = logging.getLogger(LOGGER_NAME)
 
 
 @app.task(queue='inasafe-django', default_retry_delay=10 * 60, bind=True)
-def push_shake_to_inaware(self, shake_id):
+def push_shake_to_inaware(self, shake_id, source_type):
     """
 
     :param self: Required parameter if bind=True is used
@@ -50,6 +50,7 @@ def push_shake_to_inaware(self, shake_id):
             raise Exception('Hazard id is none: %s' % shake_id)
         pdf_url = reverse('realtime_report:report_pdf', kwargs={
             'shake_id': shake_id,
+            'source_type': source_type,
             'language': 'en',
             'language2': 'en',
         })
@@ -60,6 +61,7 @@ def push_shake_to_inaware(self, shake_id):
             hazard_id, pdf_url, 'InaSAFE Estimated Earthquake Impact - EN')
         pdf_url = reverse('realtime_report:report_pdf', kwargs={
             'shake_id': shake_id,
+            'source_type': source_type,
             'language': 'id',
             'language2': 'id',
         })

--- a/django_project/realtime/tasks/headless/inasafe_wrapper.py
+++ b/django_project/realtime/tasks/headless/inasafe_wrapper.py
@@ -12,6 +12,9 @@ __revision__ = '$Format:%H$'
 LOGGER = logging.getLogger('InaSAFE Headless')
 
 
+RESULT_SUCCESS = 0
+
+
 @app.task(name='inasafe.headless.tasks.get_keywords', queue='inasafe-headless')
 def get_keywords(layer_uri, keyword=None):
     """Get keywords from a layer.

--- a/django_project/realtime/tasks/realtime/test/test_realtime_tasks.py
+++ b/django_project/realtime/tasks/realtime/test/test_realtime_tasks.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-import ast
+import errno
 import logging
 import os
 import shutil
@@ -123,10 +123,17 @@ class TestEarthquakeTasks(test.LiveServerTestCase):
         """Test generating earthquake hazard."""
         # Drop a grid file to monitored directory
         grid_file = self.fixtures_path('20180220163351-grid.xml')
+
         drop_location = os.path.join(
             EARTHQUAKE_MONITORED_DIRECTORY,
             '20180220163351',
             'grid.xml')
+
+        try:
+            os.makedirs(os.path.dirname(drop_location))
+        except OSError as e:
+            if e.errno == errno.EEXIST:
+                pass
 
         shutil.copy(grid_file, drop_location)
 

--- a/django_project/realtime/templates/realtime/earthquake/index.html
+++ b/django_project/realtime/templates/realtime/earthquake/index.html
@@ -301,10 +301,10 @@
         {#    Use magic number 000 for placeholder#}
         var report_url = '{% url "realtime:earthquake_report_detail" shake_id='000' source_type='initial' language=language.code %}';
         var report_download_url = '{% url "realtime_report:report_pdf" shake_id='000' language=language.code language2=language.code %}';
-        var grid_url = '{% url "realtime:shake_grid" shake_id='000' %}';
+        {#var grid_url = '{% url "realtime:shake_grid" shake_id='000' %}';#}
         var showReportHandler = createShowReportHandler(report_url);
         var downloadReportHandler = createDownloadReportHandler(report_download_url, '{{ language.code }}');
-        var downloadGridHandler = createDownloadGridHandler(grid_url);
+        {#var downloadGridHandler = createDownloadGridHandler(grid_url);#}
         var button_templates = [
             {
                 type: 'simple-button',
@@ -328,12 +328,13 @@
                         handler: 'downloadReportHandler'
                     },
                     {
-                        active: function(event){return event.shake_grid != undefined;},
+                        active: function(event){return event.shake_grid_download_url},
                         text: '{% trans "Grid XML" %}',
-                        handler: 'downloadGridHandler'
+                        {#handler: 'downloadGridHandler'#}
+                        href: function(event){return event.shake_grid_download_url;}
                     },
                     {
-                        active: function(event){return event.mmi_output != undefined;},
+                        active: function(event){return event.mmi_layer_exists != undefined;},
                         text: '{% trans "MMI output" %}',
                         href: function(event){return event.mmi_output;},
                         download: function(event){return event.shake_id+'-mmi.zip'}

--- a/django_project/realtime/urls.py
+++ b/django_project/realtime/urls.py
@@ -13,7 +13,7 @@ from realtime.views.earthquake import (
     EarthquakeDetail,
     EarthquakeReportList,
     EarthquakeReportDetail,
-    EarthquakeFeatureList, iframe_index, get_grid_xml)
+    EarthquakeFeatureList, iframe_index, get_grid_xml, get_analysis_zip)
 from realtime.views.flood import (
     index as flood_index,
     FloodList,
@@ -138,9 +138,16 @@ urlpatterns = format_suffix_patterns(urlpatterns)
 urlpatterns += [
     url(r'^$', shake_index, name='index'),
 
-    # SHake
+    # Shake
     url(r'^shake/$', shake_index, name='shake_index'),
-    url(r'^shake/grid/(?P<shake_id>[-\d]+)', get_grid_xml, name='shake_grid'),
+    url(r'^shake/grid/(?P<shake_id>[-\d]+)/'
+        r'(?P<source_type>\w*)/$',
+        get_grid_xml,
+        name='shake_grid'),
+    url(r'^shake/analysis/(?P<shake_id>[-\d]+)/'
+        r'(?P<source_type>\w*)/$',
+        get_analysis_zip,
+        name='analysis_zip'),
 
     # Flood
     url(r'^flood/$', flood_index, name='flood_index'),

--- a/django_project/realtime/utils.py
+++ b/django_project/realtime/utils.py
@@ -1,0 +1,97 @@
+# coding=utf-8
+import logging
+import os
+from zipfile import ZipFile
+
+from realtime.app_settings import LOGGER_NAME
+
+LOGGER = logging.getLogger(LOGGER_NAME)
+
+
+def split_layer_ext(layer_path):
+    """Split layer file by basename and extension.
+
+    We need this to accommodate parsing base_layer.aux.xml into
+    base_layer with ext .aux.xml, which is not provided os.path.splitext
+
+    :param layer_path: The path to the base file of the layer
+    :type layer_path: str
+
+    :return: A tuple of basename and extension: (basename, ext)
+    :rtype: (str, str)
+    """
+    split = layer_path.split('.')
+    # take the first as basename and the rest as ext
+    banana = split[0]
+    return banana, '.'.join([''] + split[1:])
+
+
+def zip_inasafe_layer(layer_path):
+    """Zip associated file for InaSAFE layer.
+
+    :return: Path of newly zipped file
+    """
+    # We zip files with the same basename
+    dirname = os.path.dirname(layer_path)
+    basename = os.path.basename(layer_path)
+    basename_without_ext = split_layer_ext(basename)[0]
+    zip_name = os.path.join(
+        dirname, basename_without_ext + '.zip')
+    with ZipFile(zip_name, 'w') as zf:
+        for root, dirs, files in os.walk(dirname):
+            for f in files:
+                f_basename, ext = split_layer_ext(f)
+
+                if f_basename == basename_without_ext and not ext == '.zip':
+                    filename = os.path.join(root, f)
+                    arcname = os.path.relpath(filename, dirname)
+                    zf.write(filename, arcname=arcname)
+
+    return zip_name
+
+
+def zip_inasafe_analysis_result(analysis_path):
+    """Zip associated file for InaSAFE Analysis result."""
+    # We zip files with the same basename
+    dirname = os.path.dirname(analysis_path)
+    basename = os.path.basename(analysis_path)
+    basename_without_ext = split_layer_ext(basename)[0]
+    zip_name = os.path.join(
+        dirname, basename_without_ext + '.zip')
+    with ZipFile(zip_name, 'w') as zf:
+        for root, dirs, files in os.walk(dirname):
+            for f in files:
+                f_basename, ext = split_layer_ext(f)
+
+                if not ext == '.zip':
+                    filename = os.path.join(root, f)
+                    arcname = os.path.relpath(filename, dirname)
+                    zf.write(filename, arcname=arcname)
+
+    return zip_name
+
+
+def substitute_layer_order(layer_order_template, source_dict):
+    """Replace references in layer_order_template according to source_dict.
+
+    Substitute entry that starts with @ if any
+    """
+    layer_order = []
+    for layer in layer_order_template:
+        if layer.startswith('@'):
+            # substitute layer
+            keys = layer[1:].split('.')
+            try:
+                # Recursively find indexed keys' value
+                value = source_dict
+                for k in keys:
+                    value = value[k]
+                # substitute if we find replacement
+                layer = value
+            except BaseException as e:
+                LOGGER.exception(e)
+                # Let layer order contains @ sign so it can be parsed
+                # by InaSAFE Headless instead (and decide if it will fail).
+
+        layer_order.append(layer)
+

--- a/django_project/realtime/utils.py
+++ b/django_project/realtime/utils.py
@@ -94,4 +94,3 @@ def substitute_layer_order(layer_order_template, source_dict):
                 # by InaSAFE Headless instead (and decide if it will fail).
 
         layer_order.append(layer)
-

--- a/django_project/realtime/views/earthquake.py
+++ b/django_project/realtime/views/earthquake.py
@@ -2,7 +2,6 @@
 import logging
 from copy import deepcopy
 
-import os
 from django.conf import settings
 from django.core.exceptions import ValidationError, MultipleObjectsReturned
 from django.db.utils import IntegrityError
@@ -116,21 +115,40 @@ class EarthquakeList(mixins.ListModelMixin, mixins.CreateModelMixin,
                        InBBoxFilter)
     bbox_filter_field = 'location'
     bbox_filter_include_overlapping = True
-    filter_fields = ('depth', 'magnitude', 'shake_id')
+    filter_fields = ('depth', 'magnitude', 'shake_id', 'source_type')
     filter_class = EarthquakeFilter
     search_fields = ('location_description', )
-    ordering = ('shake_id', )
+    ordering = ('shake_id', 'source_type')
     permission_classes = (DjangoModelPermissionsOrAnonReadOnly, )
 
-    def get(self, request, *args, **kwargs):
-        return self.list(request, *args, **kwargs)
+    def get(self, request, shake_id=None, source_type=None, *args, **kwargs):
+        try:
+            queryset = Earthquake.objects.all()
+            if shake_id or source_type:
+                if shake_id:
+                    queryset = queryset.filter(shake_id=shake_id)
+                if source_type:
+                    queryset = queryset.filter(source_type=source_type)
+                page = self.paginate_queryset(queryset)
+                if page is not None:
+                    serializer = self.get_serializer(page, many=True)
+                    return self.get_paginated_response(serializer.data)
+
+                serializer = self.get_serializer(queryset, many=True)
+                return Response(serializer.data)
+            else:
+                return self.list(request, *args, **kwargs)
+        except EarthquakeReport.DoesNotExist:
+            return Response(status=status.HTTP_404_NOT_FOUND)
 
     def post(self, request, *args, **kwargs):
         retval = self.create(request, *args, **kwargs)
         track_rest_push(request)
         if not settings.DEV_MODE:
             # carefuly DO NOT push it to InaWARE when in dev_mode
-            push_shake_to_inaware.delay(request.data.get('shake_id'))
+            push_shake_to_inaware.delay(
+                request.data.get('shake_id'),
+                request.data.get('source_type'))
         return retval
 
 

--- a/django_project/realtime/views/reports.py
+++ b/django_project/realtime/views/reports.py
@@ -8,7 +8,8 @@ __author__ = 'Rizky Maulana Nugraha "lucernae" <lana.pcfre@gmail.com>'
 __date__ = '19/06/15'
 
 
-def report_pdf(request, shake_id, language=u'id', language2=u'id'):
+def report_pdf(request, shake_id, source_type='initial',
+               language=u'id', language2=u'id'):
     """Return PDF file of desired shake id and language
 
     :param request: Django request object
@@ -21,6 +22,7 @@ def report_pdf(request, shake_id, language=u'id', language2=u'id'):
     try:
         report = EarthquakeReport.objects.get(
             earthquake__shake_id=shake_id,
+            earthquake__source_type=source_type,
             language=language)
         if not language == language2:
             raise Http404()
@@ -49,7 +51,8 @@ def report_pdf(request, shake_id, language=u'id', language2=u'id'):
             raise Http404()
 
 
-def report_image(request, shake_id, language=u'id', language2=u'id'):
+def report_image(request, shake_id, source_type='initial',
+                 language=u'id', language2=u'id'):
     """Return PNG file of desired shake id and language
 
     :param request: Django request object
@@ -62,6 +65,7 @@ def report_image(request, shake_id, language=u'id', language2=u'id'):
     try:
         report = EarthquakeReport.objects.get(
             earthquake__shake_id=shake_id,
+            earthquake__source_type=source_type,
             language=language)
         if not language == language2:
             raise Http404()
@@ -91,7 +95,8 @@ def report_image(request, shake_id, language=u'id', language2=u'id'):
             raise Http404()
 
 
-def report_thumbnail(request, shake_id, language=u'id', language2=u'id'):
+def report_thumbnail(request, shake_id, source_type='initial',
+                     language=u'id', language2=u'id'):
     """Return Thumbnail file of desired shake id and language
 
     Thumbnail file is a smaller-downsized version of Image report
@@ -106,6 +111,7 @@ def report_thumbnail(request, shake_id, language=u'id', language2=u'id'):
     try:
         report = EarthquakeReport.objects.get(
             earthquake__shake_id=shake_id,
+            earthquake__source_type=source_type,
             language=language)
         if not language == language2:
             raise Http404()
@@ -144,20 +150,24 @@ def latest_report(request, report_type=u'pdf', language=u'id'):
     """
     try:
         report = EarthquakeReport.objects.filter(
-            language=language).order_by('earthquake__shake_id').last()
+            language=language).order_by(
+            'earthquake__shake_id', 'earthquake__source_type').last()
 
         if not report:
             raise Http404()
 
+        shake_id = report.earthquake.shake_id
+        source_type = report.earthquake.source_type
+
         if report_type == 'pdf':
             report_pdf(
-                request, report.earthquake.shake_id, language, language)
+                request, shake_id, source_type, language, language)
         elif report_type == 'png':
             report_image(
-                request, report.earthquake.shake_id, language, language)
+                request, shake_id, source_type, language, language)
         elif report_type == 'thumbnail':
             report_thumbnail(
-                request, report.earthquake.shake_id, language, language)
+                request, shake_id, source_type, language, language)
 
         raise Http404()
     except (EarthquakeReport.DoesNotExist, IOError, AttributeError):


### PR DESCRIPTION
- Add Run Configuration for Realtime tests (in PyCharm)
- Update REQUIREMENTS.txt
- Remove check-processing-earthquake tasks
- Add support for generating Realtime REST Group for unittests
- Add earthquake fields in models for saving task result
- Refactor serializer to support source_type
- Refactor shake.js to support source_type
- Refactor earthquake views to support source_type
- Include RESULT_SUCCESS constant in inasafe_wrapper.py
- Improve unittests for Realtime service to check hazard generations
- Fix Earthquake landing page
- Refactor urls.py to support source_type
- Create utils.py for common tasks